### PR TITLE
[fix] swagger momii-playing apiの型の修正

### DIFF
--- a/swagger/v1/momii/playing.yml
+++ b/swagger/v1/momii/playing.yml
@@ -5,7 +5,7 @@ tags:
 /momii/playing:
   post:
     tags:
-    - playing
+    - Momii - playing
     parameters:
     - name: "x"
       in: "formData"
@@ -33,12 +33,12 @@ tags:
               x:
                 type: "integer"
                 format: "int64"
-                example: "1"
+                example: 1
               y:
                 type: "integer"
                 format: "int64"
-                example: "1"
+                example: 1
               userId:
                 type: "integer"
                 format: "int64"
-                example: "1"
+                example: 1


### PR DESCRIPTION
exampleがintではなく、stringになっていたのを修正