### PR TITLE
Update Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,9 @@
+require('dotenv').config();
+
+const jestIgnore = process.env.JEST_IGNORE ? process.env.JEST_IGNORE.split(',') : [];
+
 module.exports = {
-  setupFiles: [
-    '<rootDir>/tests/setup.js',
-  ],
+  setupFiles: ['<rootDir>/tests/setup.js'],
   testEnvironment: 'node',
+  testPathIgnorePatterns: jestIgnore,
 };


### PR DESCRIPTION
ファイルが増えたことで `jest --watch`に時間がかかるので、環境変数でテストを無視するパターンを指定できるように `jest.config.js` を更新

- 環境変数名は `JEST_IGNORE`
- 無視したいディレクトリ、ファイルのパターンはカンマ区切りの文字列で指定
  - 例 : `<rootDir>.*foo,<rootDir>.*bar,<rootDir>.*baz`
- dotenv で `JEST_IGNORE` が設定されていれば取得し、なければ空の配列を渡す
