### PR TITLE
挟んだらめくれるテストの追加とplaying.ymlのparameter修正

### DIFF
--- a/src/routes/api/v1/kohski/playing.js
+++ b/src/routes/api/v1/kohski/playing.js
@@ -10,6 +10,21 @@ router.use((req, res, next) => {
   next();
 });
 
+const dirAll = [
+  [0, 1],
+  [1, 1],
+  [1, 0],
+  [1, -1],
+  [0, -1],
+  [-1, -1],
+  [-1, 0],
+  [-1, 1],
+];
+
+function searchNext(pieces, nextX, nextY) {
+  return pieces.find(p => p.x === nextX && p.y === nextY);
+}
+
 router.route('/')
   .post(async (req, res) => {
     // piecesは多分盤面においてある全部のpiece
@@ -20,16 +35,56 @@ router.route('/')
       y: +req.body.y,
       userID: +req.body.userID,
     };
-
     // if the piece has already exist, return the original array
     if (pieces.find(p => p.x === result.x && p.y === result.y)) {
       res.json(pieces);
       return;
     }
 
+    // ----------------------------------------------
+    // 挟んだらめくれるテスト
+    const flip = [];
+
+    if (pieces.find(p => p.userID === result.userID)) {
+      for (let i = 0; i < dirAll.length; i += 1) {
+        const turnCandidate = [];
+
+        const dirX = dirAll[i][0];
+        const dirY = dirAll[i][1];
+        const toX = result.x + dirX;
+        const toY = result.y + dirY;
+
+        let dist = 1;
+        let dirPiece = pieces.find(p => p.x === toX && p.y === toY);
+
+        while (dirPiece !== undefined) {
+          if (dirPiece.userID !== result.userID) {
+            turnCandidate.push(dirPiece);
+            dist += 1;
+
+            const nextX = result.x + dirX * dist;
+            const nextY = result.y + dirY * dist;
+
+            dirPiece = searchNext(pieces, nextX, nextY);
+          } else if (dirPiece.userID === result.userID) {
+            for (let k = 0; k < turnCandidate.length; k += 1) {
+              if (turnCandidate[k] !== undefined) {
+                turnCandidate[k].userID = result.userID;
+                flip.push(turnCandidate[k]);
+              }
+            }
+            break;
+          }
+        }
+      }
+    }
+
     const Playing = new PlayingModel(result);
     await Playing.save();
+    await Promise.all(flip.map(p => PlayingModel.updateOne(
+      { x: p.x, y: p.y }, // 第一引数がfilter
+      { userID: p.userID }, // 第二引数でupdate
+    )));
     res.json(await PlayingModel.find({}, propFilter));
   });
-
 module.exports = router;

--- a/swagger/v1/kohski/playing.yml
+++ b/swagger/v1/kohski/playing.yml
@@ -8,39 +8,37 @@ tags:
       - Kohski-playing
     parameters:
       - name: "x"
-        in: "query"
+        in: "formData"
         description: "x axis"
         required: true
         type: "number"
       - name: "y"
-        in: "query"
+        in: "formData"
         description: "y axis"
         required: true
         type: "number"
       - name: "userID"
-        in: "query"
+        in: "formData"
         description: "user ID"
         required: true
         type: "number"
     responses:
       200:
-        description: "array"
+        description: "Playing data"
         schema:
-          type: "object"
-          properties:
-            user_id:
-              type: "string"
-              example: "aaaaaaaa"
-            name:
-              type: "string"
-              example: "aaaaaaaa"
-            email:
-              type: "string"
-              example: "aaa@aaa.aaa"
-            password:
-              type: "string"
-              example: "aaaaaaaa"
-            created:
-              type: "string"
-              example: "YYYY-MM-DD HH:mm:ss"
-  
+          type: "array"
+          items:
+            type: object
+            properties:
+              x:
+                type: "integer"
+                format: "int64"
+                example: 1
+              y:
+                type: "integer"
+                format: "int64"
+                example: 1
+              userId:
+                type: "integer"
+                format: "int64"
+                example: 1  

--- a/tests/routes/api/v1/kohski/playing.test.js
+++ b/tests/routes/api/v1/kohski/playing.test.js
@@ -187,9 +187,86 @@ describe('play', () => {
       expect(pieceData).toEqual(expect.arrayContaining(matchers));
     });
 
-    // // 挟んだらめくれるテスト
+    // 挟んだらめくれるテスト
+    it('turnover pieces', async () => {
+      // Given
+      const pieces = array2pieces(
+        [
+          ['1:6', '2:4', '1:1', 0],
+          ['2:2', 0, 0, 0],
+          ['3:3', 0, 0, 0],
+          ['1:5', 0, 0, 0],
+        ],
+      );
+      const matchers = array2pieces(
+        [
+          [1, 1, 1, 0],
+          [1, 0, 0, 0],
+          [1, 0, 0, 0],
+          [1, 0, 0, 0],
+        ],
+      );
+
+      // When
+      let response;
+
+      for (let i = 0; i < pieces.length; i += 1) {
+        response = await chai.request(app)
+          .post(`${basePath}/kohski/playing`)
+          .set('content-type', 'application/x-www-form-urlencoded')
+          .send(pieces[i]);
+      }
+
+      // Then
+      // expressの検証
+      expect(response.body).toHaveLength(pieces.length);
+      expect(response.body).toEqual(expect.arrayContaining(matchers));
+
+      // mongodbの検証
+      const pieceData = JSON.parse(JSON.stringify(await PlayingModel.find({}, propFilter)));
+      expect(pieceData).toHaveLength(pieces.length);
+      expect(pieceData).toEqual(expect.arrayContaining(matchers));
+    });
 
     // はなれたところにおけないテスト
+    it('cannot put on remote cell', async () => {
+      // Given
+      const pieces = array2pieces(
+        [
+          ['1:1', '2:2', 0],
+          [0, 0, 0],
+          ['3:3', 0, 0],
+        ],
+      );
+      const matchers = array2pieces(
+        [
+          [1, 2, 0],
+          [0, 0, 0],
+          [0, 0, 0],
+        ],
+      );
+
+      // When
+      let response;
+
+      for (let i = 0; i < pieces.length; i += 1) {
+        response = await chai.request(app)
+          .post(`${basePath}/kohski/playing`)
+          .set('content-type', 'application/x-www-form-urlencoded')
+          .send(pieces[i]);
+      }
+
+      // Then
+      // expressの検証
+      expect(response.body).toHaveLength(pieces.length);
+      expect(response.body).toEqual(expect.arrayContaining(matchers));
+
+      // mongodbの検証
+      const pieceData = JSON.parse(JSON.stringify(await PlayingModel.find({}, propFilter)));
+      expect(pieceData).toHaveLength(pieces.length);
+      expect(pieceData).toEqual(expect.arrayContaining(matchers));
+    });
+
 
     // 自分のがあったらめくれるところにしかおけない
   });

--- a/tests/routes/api/v1/kohski/playing.test.js
+++ b/tests/routes/api/v1/kohski/playing.test.js
@@ -229,45 +229,6 @@ describe('play', () => {
     });
 
     // はなれたところにおけないテスト
-    it('cannot put on remote cell', async () => {
-      // Given
-      const pieces = array2pieces(
-        [
-          ['1:1', '2:2', 0],
-          [0, 0, 0],
-          ['3:3', 0, 0],
-        ],
-      );
-      const matchers = array2pieces(
-        [
-          [1, 2, 0],
-          [0, 0, 0],
-          [0, 0, 0],
-        ],
-      );
-
-      // When
-      let response;
-
-      for (let i = 0; i < pieces.length; i += 1) {
-        response = await chai.request(app)
-          .post(`${basePath}/kohski/playing`)
-          .set('content-type', 'application/x-www-form-urlencoded')
-          .send(pieces[i]);
-      }
-
-      // Then
-      // expressの検証
-      expect(response.body).toHaveLength(pieces.length);
-      expect(response.body).toEqual(expect.arrayContaining(matchers));
-
-      // mongodbの検証
-      const pieceData = JSON.parse(JSON.stringify(await PlayingModel.find({}, propFilter)));
-      expect(pieceData).toHaveLength(pieces.length);
-      expect(pieceData).toEqual(expect.arrayContaining(matchers));
-    });
-
-
     // 自分のがあったらめくれるところにしかおけない
   });
 });


### PR DESCRIPTION
(1)ireversi-server/src/routes/api/v1/kohski/playing.js
 挟んだらめくれる機能を追加しました。

(2)ireversi-server/tests/routes/api/v1/kohski/playing.test.js
 挟んだらめくれるテストを追加しました。

(3)ireversi-server/swagger/v1/kohski/playing.yml
 parameterのin:がquery担っていたので、formDataに変更しました。

ご確認よろしくお願いいたします。