### PR TITLE
fix: piece.test

### DIFF
--- a/src/models/v2/PieceStore.js
+++ b/src/models/v2/PieceStore.js
@@ -60,21 +60,35 @@ module.exports = {
     const array = []; // 返す配列
     const sqrt = Math.sqrt(source.length); // 平方根
     const sourceExist = [];
+    // 送られた配列から0をスキップ、要素が配列になっているものをばらした配列を生成
     for (let i = 0; i < source.length; i += 1) {
-      const f = source[i];
-      if (Array.isArray(f)) {
-        const g = [i, f[0], true];
-        sourceExist.push(g);
-        for (let j = 1; j < f.length; j += 1) {
-          const h = [i, f[j], false];
+      const element = source[i];
+      if (Array.isArray(element)) { // 要素が配列の場合
+        for (let j = 0; j < element.length; j += 1) {
+          const h = [i, element[j]];
           sourceExist.push(h);
         }
-      } else if (f !== 0) {
-        const g = [i, f, true];
-        sourceExist.push(g);
+      } else if (element !== 0) {
+        const h = [i, element];
+        sourceExist.push(h);
       }
     }
+
+    // 要素にfがあるかないかでtrueかfalseを決定
+    for (let i = 0; i < sourceExist.length; i += 1) {
+      const el = sourceExist[i];
+      const order = el[0];
+      if (el[1].match(/f/)) { // fがついていたらfalseを付与、なければtrueを付与
+        const piece = el[1].replace(/:f/, ''); // :fの文字を削除
+        sourceExist[i] = [order, piece, false];
+      } else {
+        sourceExist[i] = [order, el[1], true];
+      }
+    }
+
+    // プレイ順に並び替え
     const playOrder = sourceExist.sort((a, b) => (parseInt(a[1].slice(a[1].indexOf(':') + 1), 10)) - (parseInt(b[1].slice(b[1].indexOf(':') + 1), 10)));
+
     let n = 0;
     let elm = {};
     for (let i = 0; i < playOrder.length; i += 1) { // x, y, userIdを生成する

--- a/tests/routes/api/v2/piece/piece.test.js
+++ b/tests/routes/api/v2/piece/piece.test.js
@@ -4,9 +4,103 @@ const app = require('../../../../../src/routes/app.js');
 
 const basePath = '/api/v2/piece/';
 
-describe('play', () => {
+describe('piece', () => {
+  // デバッグ検証
+  // 盤面に自コマがあるときは、他コマがめくれるところだけおける
+  it('cannot be put unless it can flip another piece', async () => {
+    // Reset
+    await chai.request(app).delete(`${basePath}`);
+
+    // Given
+    const pieces = PieceStore.array2Pieces(
+      [
+        0, '2:2', 0,
+        0, '1:1', '1:3',
+        0, 0, 0,
+      ],
+    );
+
+    // 置けないコマは'1:3:f'と、最後にfを付ける
+    const matches = PieceStore.array2Matchers(
+      [
+        0, '2:2', 0,
+        0, '1:1', '1:3:f',
+        0, 0, 0,
+      ],
+    );
+
+    // When
+    let response;
+    for (let i = 0; i < pieces.length; i += 1) {
+      const match = matches[i];
+
+      response = await chai.request(app)
+        .post(`${basePath}`)
+        .query({ userId: pieces[i].userId })
+        .set('content-type', 'application/x-www-form-urlencoded')
+        .send(pieces[i]);
+
+      // Then
+      expect(response.body).toEqual(match);
+      expect(response.body).toEqual(expect.objectContaining({
+        status: match.status,
+        piece: {
+          x: match.piece.x,
+          y: match.piece.y,
+          userId: match.piece.userId,
+        },
+      }));
+    }
+  });
+
+  // デバッグ検証、同じところに置けないテスト
+  it('cannot be put on the same place', async () => {
+    // Reset
+    await chai.request(app).delete(`${basePath}`);
+
+    // Given
+    const pieces = PieceStore.array2Pieces(
+      [
+        0, ['2:2', '2:4', '1:5'], 0,
+        0, ['1:1', '1:3'], 0,
+        0, 0, 0,
+      ],
+    );
+
+    const matches = PieceStore.array2Matchers(
+      [
+        0, ['2:2', '2:4:f', '1:5:f'], 0,
+        0, ['1:1', '1:3:f'], 0,
+        0, 0, 0,
+      ],
+    );
+
+    // When
+    let response;
+    for (let i = 0; i < pieces.length; i += 1) {
+      const match = matches[i];
+
+      response = await chai.request(app)
+        .post(`${basePath}`)
+        .query({ userId: pieces[i].userId })
+        .set('content-type', 'application/x-www-form-urlencoded')
+        .send(pieces[i]);
+
+      // Then
+      expect(response.body).toEqual(match);
+      expect(response.body).toEqual(expect.objectContaining({
+        status: match.status,
+        piece: {
+          x: match.piece.x,
+          y: match.piece.y,
+          userId: match.piece.userId,
+        },
+      }));
+    }
+  });
+
   // 一つ駒を置く
-  it('put a piece', async () => {
+  it('is put', async () => {
     // Reset
     await chai.request(app).delete(`${basePath}`);
 
@@ -49,158 +143,25 @@ describe('play', () => {
     }
   });
 
-  // 複数駒を置く
-  it('sets multi pieces', async () => {
+  // 離れたところは置けない1
+  it('never become alone (far away from the other pieces)', async () => {
     // Reset
     await chai.request(app).delete(`${basePath}`);
 
     // Given
     const pieces = PieceStore.array2Pieces(
       [
-        0, 0,
-        '1:1', '2:2',
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        0, 0,
-        '1:1', '2:2',
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
-
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // 同じところにおけないテスト
-  it('sets pieces same space', async () => {
-    // Reset
-    await chai.request(app).delete(`${basePath}`);
-
-    // Given
-    const pieces = PieceStore.array2Pieces(
-      [
-        0, 0,
-        '1:1', ['2:2', '1:3'],
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        0, 0,
-        '1:1', ['2:2', '1:3'],
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
-
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // 挟んだらめくれるテスト（左方向、上方向） part1
-  it('turn over piece about left and up', async () => {
-    // Reset
-    await chai.request(app).delete(`${basePath}`);
-
-    // Given
-    const pieces = PieceStore.array2Pieces(
-      [
-        '1:5', 0, 0,
-        '2:4', 0, 0,
-        '1:1', '2:2', '1:3',
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        '1:5', 0, 0,
-        '2:4', 0, 0,
-        '1:1', '2:2', '1:3',
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
-
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // 挟んだらめくれるテスト part2（右方向、下方向）
-  it('turn over piece about right and down', async () => {
-    // Reset
-    await chai.request(app).delete(`${basePath}`);
-
-    // Given
-    const pieces = PieceStore.array2Pieces(
-      [
-        '1:3', '2:2', '1:1',
+        '1:1', 0, 0,
         0, 0, '2:4',
-        0, 0, '1:5',
+        0, '2:3', '2:2',
       ],
     );
 
     const matches = PieceStore.array2Matchers(
       [
-        '1:3', '2:2', '1:1',
-        0, 0, '2:4',
-        0, 0, '1:5',
+        '1:1', 0, 0,
+        0, 0, '2:4:f',
+        0, '2:3:f', '2:2:f',
       ],
     );
 
@@ -208,6 +169,7 @@ describe('play', () => {
     let response;
     for (let i = 0; i < pieces.length; i += 1) {
       const match = matches[i];
+
       response = await chai.request(app)
         .post(`${basePath}`)
         .query({ userId: pieces[i].userId })
@@ -227,27 +189,25 @@ describe('play', () => {
     }
   });
 
-  // 挟んだらめくれるテスト part3
-  it('turn over piece about upper left and lower left', async () => {
+  // 離れたところは置けない2
+  it('never become alone (far away from the other pieces)', async () => {
     // Reset
     await chai.request(app).delete(`${basePath}`);
 
     // Given
     const pieces = PieceStore.array2Pieces(
       [
-        0, 0, 0, '1:6',
-        '1:1', '2:2', '3:5', 0,
-        0, '3:3', 0, 0,
-        0, 0, '1:4', 0,
+        '1:1', 0, '2:2',
+        0, 0, 0,
+        0, 0, 0,
       ],
     );
 
     const matches = PieceStore.array2Matchers(
       [
-        0, 0, 0, '1:6',
-        '1:1', '2:2', '3:5', 0,
-        0, '3:3', 0, 0,
-        0, 0, '1:4', 0,
+        '1:1', 0, '2:2:f',
+        0, 0, 0,
+        '2:3:f', 0, 0,
       ],
     );
 
@@ -255,6 +215,7 @@ describe('play', () => {
     let response;
     for (let i = 0; i < pieces.length; i += 1) {
       const match = matches[i];
+
       response = await chai.request(app)
         .post(`${basePath}`)
         .query({ userId: pieces[i].userId })
@@ -274,27 +235,25 @@ describe('play', () => {
     }
   });
 
-  // 挟んだらめくれるテスト part4
-  it('turn over piece about upper right and lower right', async () => {
+  // １手目の場合、斜めに置けないテスト
+  it('can be put on cell next to the other pieces not on diagle cells', async () => {
     // Reset
     await chai.request(app).delete(`${basePath}`);
 
     // Given
     const pieces = PieceStore.array2Pieces(
       [
-        '1:6', 0, 0, 0,
-        0, '3:5', '2:2', '1:1',
-        0, 0, '3:3', 0,
-        0, '1:4', 0, 0,
+        '2:3', 0, ['2:2', '2:6'],
+        0, '1:1', 0,
+        '2:4', 0, '2:5',
       ],
     );
 
     const matches = PieceStore.array2Matchers(
       [
-        '1:6', 0, 0, 0,
-        0, '3:5', '2:2', '1:1',
-        0, 0, '3:3', 0,
-        0, '1:4', 0, 0,
+        '2:3:f', 0, ['2:2:f', '2:6:f'],
+        0, '1:1', 0,
+        '2:4:f', 0, '2:5:f',
       ],
     );
 
@@ -302,6 +261,7 @@ describe('play', () => {
     let response;
     for (let i = 0; i < pieces.length; i += 1) {
       const match = matches[i];
+
       response = await chai.request(app)
         .post(`${basePath}`)
         .query({ userId: pieces[i].userId })
@@ -321,28 +281,25 @@ describe('play', () => {
     }
   });
 
-  // 場に一枚も置いてない場合の駒置きテスト（反転無し） part1
-  it('in the case about nothing own piece, not turn over', async () => {
+  // 盤面に自コマがない場合、他コマの上下左右だけおける。斜めには置けないテスト。
+  it('can be put on a cell next to the other pieces', async () => {
     // Reset
     await chai.request(app).delete(`${basePath}`);
 
     // Given
     const pieces = PieceStore.array2Pieces(
       [
-        0, 0, '4:5', 0,
-        0, '3:3', 0, 0,
-        0, '1:1', '1:4', 0,
-        0, '2:2', 0, 0,
+        '1:1', '2:4', 0,
+        0, ['3:3', '3:5'], 0,
+        0, 0, '2:2',
       ],
     );
 
-
     const matches = PieceStore.array2Matchers(
       [
-        0, 0, '4:5', 0,
-        0, '3:3', 0, 0,
-        0, '1:1', '1:4', 0,
-        0, '2:2', 0, 0,
+        '1:1', '2:4', 0,
+        0, ['3:3:f', '3:5'], 0,
+        0, 0, '2:2:f',
       ],
     );
 
@@ -350,240 +307,7 @@ describe('play', () => {
     let response;
     for (let i = 0; i < pieces.length; i += 1) {
       const match = matches[i];
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
 
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // 場に一枚も置いてない場合の駒置きテスト（反転有り） part2
-  it('the case about nothing own piece, to turn over', async () => {
-    // Reset
-    await chai.request(app).delete(`${basePath}`);
-    // Given
-    const pieces = PieceStore.array2Pieces(
-      [
-        0, '1:4', '3:6', 0,
-        0, '3:3', 0, 0,
-        0, '1:1', '2:5', 0,
-        0, '2:2', 0, 0,
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        0, '1:4', '3:6', 0,
-        0, '3:3', 0, 0,
-        0, '1:1', '2:5', 0,
-        0, '2:2', 0, 0,
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
-
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // 場に駒がある場合の駒置きテスト（上下左右チェック） part1
-  it('the case about exist own piece, check to turn over four direction', async () => {
-    // Reset
-    await chai.request(app).delete(`${basePath}`);
-
-    // Given
-    const pieces = PieceStore.array2Pieces(
-      [
-        '1:15', '1:14', '1:13', '1:12', '1:11',
-        '1:16', 0, '4:4', 0, '1:10',
-        '1:18', '5:17', '1:1', '3:3', '1:9',
-        '1:19', 0, '2:2', 0, '1:8',
-        '1:20', '1:21', '1:5', '1:6', '1:7',
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        '1:15', '1:14', '1:13', '1:12', '1:11',
-        '1:16', 0, '4:4', 0, '1:10',
-        '1:18', '5:17', '1:1', '3:3', '1:9',
-        '1:19', 0, '2:2', 0, '1:8',
-        '1:20', '1:21', '1:5', '1:6', '1:7',
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
-
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // 場に駒がある場合の駒置きテスト（斜めの4方向チェック） part2
-  it('the case about exist own piece, check to turn over four direction', async () => {
-    // Reset
-    await chai.request(app).delete(`${basePath}`);
-
-    // Given
-    const pieces = PieceStore.array2Pieces(
-      [
-        '1:15', 0, 0, 0, '1:14',
-        '1:16', '8:8', '4:4', '7:7', '1:13',
-        '1:17', '5:5', '1:1', '3:3', '1:12',
-        0, '9:9', '2:2', '6:6', '1:11',
-        '1:18', 0, 0, 0, '1:10',
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        '1:15', 0, 0, 0, '1:14',
-        '1:16', '8:8', '4:4', '7:7', '1:13',
-        '1:17', '5:5', '1:1', '3:3', '1:12',
-        0, '9:9', '2:2', '6:6', '1:11',
-        '1:18', 0, 0, 0, '1:10',
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
-
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // マスが空いて飛び石になっている場合に置けないテスト
-  it('the test piece cannnot skip the blank cell to flip ', async () => {
-    await chai.request(app).delete(`${basePath}`);
-
-    const pieces = PieceStore.array2Pieces(
-      [
-        0, '1:7', 0, 0, 0,
-        0, '6:6', '5:5', 0, 0,
-        0, 0, '4:4', 0, 0,
-        0, '2:2', '3:3', 0, 0,
-        0, '1:1', 0, 0, 0,
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        0, '1:7', 0, 0, 0,
-        0, '6:6', '5:5', 0, 0,
-        0, 0, '4:4', 0, 0,
-        0, '2:2', '3:3', 0, 0,
-        0, '1:1', 0, 0, 0,
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
-      response = await chai.request(app)
-        .post(`${basePath}`)
-        .query({ userId: pieces[i].userId })
-        .set('content-type', 'application/x-www-form-urlencoded')
-        .send(pieces[i]);
-
-      // Then
-      expect(response.body).toEqual(match);
-      expect(response.body).toEqual(expect.objectContaining({
-        status: match.status,
-        piece: {
-          x: match.piece.x,
-          y: match.piece.y,
-          userId: match.piece.userId,
-        },
-      }));
-    }
-  });
-
-  // 同じところに全然置けないテスト
-  it('the test piece cannnot skip the blank cell to flip ', async () => {
-    await chai.request(app).delete(`${basePath}`);
-
-    const pieces = PieceStore.array2Pieces(
-      [
-        0, ['3:3', '5:5'], 0,
-        0, ['1:1', '2:2'], 0,
-        '4:4', '2:3', 0,
-      ],
-    );
-
-    const matches = PieceStore.array2Matchers(
-      [
-        0, ['3:3', '5:5'], 0,
-        0, ['1:1', '2:2'], 0,
-        '4:4', '2:3', 0,
-      ],
-    );
-
-    // When
-    let response;
-    for (let i = 0; i < pieces.length; i += 1) {
-      const match = matches[i];
       response = await chai.request(app)
         .post(`${basePath}`)
         .query({ userId: pieces[i].userId })


### PR DESCRIPTION
# piece.test.js
-  `piece.test.js` ではpiece１手ずつの返り値を検証
----
## 修正点
-  `array2Matches` の配列生成メソッドを変更
-  `matches` の要素 `1:2:f` は、「 `userId:1` が `2手目` に置いて、結果 `f(false)` だった」の意味 
```
const matches = PieceStore.array2Matchers(
  [
    '1:1', '1:2:f',
    ['2:3', '3:4'], '2:5:f'
  ],
);
// 上の座面は下記のように生成される
// [
//   { status: true, piece: { x: 0, y: 1, userId: 1 } }, 
//   { status: false, piece: { x: 1, y: 1, userId: 1 } },
//   { status: true, piece: { x: 0, y: 0, userId: 2 } },  
//   { status: true, piece: { x: 0, y: 0, userId: 3 } },
//   { status: false, piece: { x: 1, y: 0, userId: 2 } }
// ]
```
