### PR TITLE
userId発行の際にusenameを強制する処理の追加

### DIFF
--- a/src/routes/api/v2/userIdGenerate/index.js
+++ b/src/routes/api/v2/userIdGenerate/index.js
@@ -3,9 +3,26 @@ const jwt = require('jsonwebtoken');
 const generateToken = require('./generateToken');
 
 router.route('/').post((req, res) => {
+  const ans = {};
   const accessToken = generateToken.generate();
   const { userId } = jwt.decode(accessToken);
-  res.json({ accessToken, userId });
+  const { username } = req.headers;
+
+  // 正規表現でusernameのvalidation
+  // 数値、アルファベット、_以外が出たらtrueを返す正規表現
+  const reg = /^[a-z0-9]([_a-z0-9]){2,13}[a-z0-9]$/;
+
+  // 禁止文字の検索、最短の検索、最長の検索
+  if (reg.test(username)) {
+    ans.accessToken = accessToken;
+    ans.userId = userId;
+    ans.username = username;
+  } else {
+    ans.accessToken = null;
+    ans.userId = null;
+    ans.username = null;
+  }
+  res.json(ans);
 });
 
 module.exports = router;

--- a/swagger/v2/swagger.yml
+++ b/swagger/v2/swagger.yml
@@ -344,6 +344,13 @@ definitions:
       - "userId"
     summary: "generate new userId by JWT"
     description: "userIdの新規生成"
+    parameters:
+      - name: username
+        in: "header"
+        description: "input user name "
+        type: string
+        example: 
+        required: true
     responses:
       200:
         description: "return a new userId"

--- a/tests/routes/api/v2/userIdGenerate/userIdGenerate.test.js
+++ b/tests/routes/api/v2/userIdGenerate/userIdGenerate.test.js
@@ -1,0 +1,43 @@
+const chai = require('chai');
+// const jwt = require('jsonwebtoken');
+const app = require('../../../../../src/routes/app.js');
+// const PieceStore = require('../../../../../src/models/v2/PieceStore.js');
+const generateToken = require('../../../../../src/routes/api/v2/userIdGenerate/generateToken');
+
+const basePath = '/api/v2';
+
+function userIdGenerate() {
+  const token = generateToken.generate();
+  return token;
+}
+
+describe('userId generate', () => {
+  // 一つ駒を置く
+  it('generates userId and request userName', async () => {
+    // Given
+    const userIdJwt = userIdGenerate();
+    const userName = 'test_kimkim';
+
+    // When
+    const response = await chai.request(app)
+      .post(`${basePath}/user_id_generate`)
+      .set('userName', userName);
+      // Then
+    expect(response.body.accessToken.length).toEqual(userIdJwt.length);
+  });
+
+
+  it('generates userId and request invalid userName', async () => {
+    // Given
+    const userName = 'test-kimkim';
+
+    // When
+    const response = await chai.request(app)
+      .post(`${basePath}/user_id_generate`)
+      .set('username', userName);
+      // Then
+    expect(response.body.accessToken).toEqual(null);
+    expect(response.body.userId).toEqual(null);
+    expect(response.body.username).toEqual(null);
+  });
+});


### PR DESCRIPTION
今まで失念していたuserIdGenerateのtestを追加しました。

userId発行の際にusernameをheaderに入れてもらうようにしたので、
それを取得して、validationが通った場合にのみuserIdとそのjwt形式を返すようにしました。
validation通過できなかったものは,accessToken,userId,username全てnullで返すようにしました。

よろしくお願いいたします。