### PR TITLE
テスト修正およびrestoreMongo内ソート処理追加

### DIFF
--- a/src/utils/restoreMongo.js
+++ b/src/utils/restoreMongo.js
@@ -7,6 +7,8 @@ const restore = true;
 module.exports = {
   async restoreMongo() {
     const mg = await JSON.parse(JSON.stringify(await BoardHistoryModel.find({}, propFilter)));
+    // Mongoのデータが日付順に格納されているとは限らないため並び替え
+    mg.sort((a, b) => (a.date > b.date ? 1 : -1));
 
     for (let i = 0; i < mg.length; i += 1) {
       const { x, y, userId } = mg[i].piece;

--- a/tests/routes/api/v2/piece/piece.test.js
+++ b/tests/routes/api/v2/piece/piece.test.js
@@ -103,9 +103,8 @@ describe('piece', () => {
       expect(pieceData).toHaveLength(matchesDB.length);
 
       // matchesから
-      for (let i = 0; i < pieceData.length; i += 1) {
-        const pc = pieceData[i];
-        expect(pc.piece).toEqual(expect.objectContaining(matchesDB[i].piece));
+      for (let i = 0; i < matchesDB.length; i += 1) {
+        expect(pieceData).toContainEqual(expect.objectContaining({ piece: matchesDB[i].piece }));
       }
       await sendMongo.stopSendingMongo();
     });

--- a/tests/utils/sendMongo.test.js
+++ b/tests/utils/sendMongo.test.js
@@ -111,11 +111,9 @@ describe('piece', () => {
 
       // When
       // 1ピースずつ確認
-      for (let i = 0; i < resPieces.length; i += 1) {
-        const resPiece = resPieces[i];
-        const match = matchesDB[i].piece;
+      for (let i = 0; i < matchesDB.length; i += 1) {
         // Then
-        expect(resPiece).toEqual(match);
+        expect(resPieces).toContainEqual(expect.objectContaining(matchesDB[i].piece));
       }
       expect(resPieces).toHaveLength(matchesDB.length); // x: 0, y: 0のデフォルト値を考慮
     });


### PR DESCRIPTION
### 'cannot be put on the same place3'のテスト修正
- tests/routes/api/v2/piece/piece.test.js
Mongoと検証用のデータとで配列の順序が異なってもテストが通るよう変更

### 'restoreMongo.restoreMongo()'の処理追加
- src/utils/restoreMongo.js
Mongoのデータは、日付順に格納されているとは限らないため、日付順に並び替えてからリストアするよう変更
参考までにリストアが失敗するときのデータと並び替え後のデータのログを添付します。
- tests/utils/sendMongo.test.js
`piece.test.js` と同じ修正
```
PASS  tests/utils/sendMongo.test.js (5.365s)
  ● Console

    console.log src/utils/restoreMongo.js:10
      BoardHistory(Before)    console.log src/utils/restoreMongo.js:11
      [ { piece: { x: 0, y: 1, userId: 'tIGSg6' },
          method: 'post',          path: 'piece',
          date: '2018-11-04T14:28:52.387Z' },
        { piece: { x: 2, y: 1, userId: 'tIGSg6' },
          method: 'post',
          path: 'piece',
          date: '2018-11-04T14:28:52.412Z' },
        { piece: { x: 1, y: 1, userId: 'Qr9nZy' },
          method: 'post',
          path: 'piece',
          date: '2018-11-04T14:28:52.405Z' } ]
    console.log src/utils/restoreMongo.js:13
      BoardHistory(After)
    console.log src/utils/restoreMongo.js:14
      [ { piece: { x: 0, y: 1, userId: 'tIGSg6' },
          method: 'post',
          path: 'piece',
          date: '2018-11-04T14:28:52.387Z' },
        { piece: { x: 1, y: 1, userId: 'Qr9nZy' },
          method: 'post',
          path: 'piece',
          date: '2018-11-04T14:28:52.405Z' },
        { piece: { x: 2, y: 1, userId: 'tIGSg6' },
          method: 'post',
          path: 'piece',
          date: '2018-11-04T14:28:52.412Z' } ]
```